### PR TITLE
Load MySQL config from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ gemini
 - Explore the available **[CLI Commands](./docs/cli/commands.md)**.
 - If you encounter any issues, review the **[Troubleshooting guide](./docs/troubleshooting.md)**.
 - For more comprehensive documentation, see the [full documentation](./docs/index.md).
+- For instructions on configuring MySQL connections, see [MySQL Configuration](./docs/mysql-config.md).
 - Take a look at some [popular tasks](#popular-tasks) for more inspiration.
 
 ### Troubleshooting

--- a/config.py
+++ b/config.py
@@ -50,15 +50,17 @@ else:
     DATABASE_TYPE = 'sqlite'  # MySQL yoksa zorla SQLite
 
 # MySQL Konfigürasyonu
+# MySQL configuration can be provided via environment variables. Default values
+# below are useful for local development.
 MYSQL_CONFIG = {
-    'host': 'localhost',
-    'database': 'effinova_db',
-    'user': 'root',
-    'password': '',  # MYSQL ŞİFRENİZİ BURAYA YAZIN
-    'port': 3306,
-    'charset': 'utf8mb4',
-    'collation': 'utf8mb4_unicode_ci',
-    'autocommit': True
+    'host': os.getenv('MYSQL_HOST', 'localhost'),
+    'database': os.getenv('MYSQL_DATABASE', 'effinova_db'),
+    'user': os.getenv('MYSQL_USER', 'root'),
+    'password': os.getenv('MYSQL_PASSWORD', ''),
+    'port': int(os.getenv('MYSQL_PORT', '3306')),
+    'charset': os.getenv('MYSQL_CHARSET', 'utf8mb4'),
+    'collation': os.getenv('MYSQL_COLLATION', 'utf8mb4_unicode_ci'),
+    'autocommit': os.getenv('MYSQL_AUTOCOMMIT', 'True').lower() in ('true', '1', 'yes')
 }
 
 # SQLite Konfigürasyonu

--- a/docs/mysql-config.md
+++ b/docs/mysql-config.md
@@ -1,0 +1,21 @@
+# MySQL Configuration
+
+The optional `config.py` module includes a `MYSQL_CONFIG` dictionary for connecting to a MySQL database. Beginning with this version, connection details are read from environment variables so credentials do not have to be stored in the source code.
+
+## Required variables
+
+Set the following variables in your shell or in a `.env` file before running the application:
+
+```bash
+export MYSQL_HOST="localhost"
+export MYSQL_DATABASE="effinova_db"
+export MYSQL_USER="root"
+export MYSQL_PASSWORD="password"
+# Optional
+export MYSQL_PORT="3306"
+export MYSQL_CHARSET="utf8mb4"
+export MYSQL_COLLATION="utf8mb4_unicode_ci"
+export MYSQL_AUTOCOMMIT="True"
+```
+
+Default values (shown above) are used when a variable is not defined, which makes local development simple. For production deployments, be sure to provide secure values for `MYSQL_USER` and `MYSQL_PASSWORD`.


### PR DESCRIPTION
## Summary
- pull MySQL connection details from environment variables
- document MySQL environment variables
- link MySQL config docs from the README

## Testing
- `npm run test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b9e4dd1808326b6028ccc20620283